### PR TITLE
Remove animation accessibility setting when accessibility setting is toggled

### DIFF
--- a/app/components/animated_number/index.tsx
+++ b/app/components/animated_number/index.tsx
@@ -4,6 +4,8 @@
 import React, {useCallback, useEffect, useMemo, useState} from 'react';
 import {Animated, Easing, type LayoutChangeEvent, type StyleProp, Text, type TextStyle, View} from 'react-native';
 
+import {useReduceMotion} from '@hooks/device';
+
 interface Props {
     animateToNumber: number;
     fontStyle?: StyleProp<TextStyle>;
@@ -30,6 +32,7 @@ const AnimatedNumber = ({
 }: Props) => {
     const previousNumber = usePrevious(animateToNumber);
     const [numberHeight, setNumberHeight] = useState(0);
+    const reduceMotion = useReduceMotion();
 
     const animateToNumberString = String(Math.abs(animateToNumber));
 
@@ -66,7 +69,7 @@ const AnimatedNumber = ({
     }, [animateToNumberString, numberHeight, previousNumberString]);
 
     useEffect(() => {
-        if (!numberHeight) {
+        if (!numberHeight || reduceMotion) {
             return;
         }
 
@@ -85,11 +88,24 @@ const AnimatedNumber = ({
         animations,
         easing,
         numberHeight,
+        reduceMotion,
     ]);
 
     const setButtonLayout = useCallback((e: LayoutChangeEvent) => {
         setNumberHeight(e.nativeEvent.layout.height);
     }, []);
+
+    // If reduce motion is enabled, just show the number without animation
+    if (reduceMotion) {
+        return (
+            <Text
+                style={[fontStyle]}
+                testID={'no-animation-number'}
+            >
+                {animateToNumber < 0 ? '-' : ''}{animateToNumberString}
+            </Text>
+        );
+    }
 
     return (
         <>

--- a/app/components/option_box/animated.tsx
+++ b/app/components/option_box/animated.tsx
@@ -7,6 +7,7 @@ import Animated, {Easing, interpolate, interpolateColor, runOnJS, useAnimatedSty
 
 import CompassIcon from '@components/compass_icon';
 import {useTheme} from '@context/theme';
+import {useReduceMotion} from '@hooks/device';
 import {changeOpacity, makeStyleSheetFromTheme} from '@utils/theme';
 import {typography} from '@utils/typography';
 
@@ -56,12 +57,18 @@ const AnimatedOptionBox = ({
     const styles = getStyleSheet(theme);
     const [activated, setActivated] = useState(false);
     const animate = useSharedValue(0);
+    const reduceMotion = useReduceMotion();
 
     const handleOnPress = useCallback(() => {
-        animate.value = withTiming(1, {duration: 150, easing: Easing.out(Easing.linear)});
-        setActivated(true);
+        if (!reduceMotion) {
+            animate.value = withTiming(1, {duration: 150, easing: Easing.out(Easing.linear)});
+            setActivated(true);
+        } else if (onAnimationEnd) {
+            // If animations are disabled, immediately call the animation end callback
+            onAnimationEnd();
+        }
         onPress();
-    }, [animate, onPress]);
+    }, [animate, onPress, onAnimationEnd, reduceMotion]);
 
     const backgroundStyle = useAnimatedStyle(() => ({
         backgroundColor: interpolateColor(
@@ -112,6 +119,36 @@ const AnimatedOptionBox = ({
             }
         };
     }, [activated, animate, onAnimationEnd]);
+
+    // If reduce motion is enabled, render a simpler version without animations
+    if (reduceMotion) {
+        return (
+            <Pressable
+                onPress={handleOnPress}
+                style={styles.container}
+                testID={testID}
+            >
+                {({pressed}) => (
+                    <View style={[styles.container, styles.background, pressed && {backgroundColor: changeOpacity(theme.buttonBg, 0.16)}]}>
+                        <View style={[styles.container, styles.center]}>
+                            <CompassIcon
+                                color={pressed ? theme.buttonBg : changeOpacity(theme.centerChannelColor, 0.56)}
+                                name={iconName}
+                                size={24}
+                            />
+                            <Text
+                                numberOfLines={1}
+                                style={[styles.text, {color: pressed ? theme.buttonBg : changeOpacity(theme.centerChannelColor, 0.56)}]}
+                                testID={`${testID}.label`}
+                            >
+                                {text}
+                            </Text>
+                        </View>
+                    </View>
+                )}
+            </Pressable>
+        );
+    }
 
     return (
         <AnimatedPressable

--- a/app/hooks/device.ts
+++ b/app/hooks/device.ts
@@ -3,7 +3,7 @@
 
 import RNUtils, {type WindowDimensions} from '@mattermost/rnutils';
 import React, {type RefObject, useEffect, useRef, useState, useContext} from 'react';
-import {AppState, Keyboard, NativeEventEmitter, Platform, View} from 'react-native';
+import {AccessibilityInfo, AppState, Keyboard, NativeEventEmitter, Platform, View} from 'react-native';
 import {useSafeAreaInsets} from 'react-native-safe-area-context';
 
 import {DeviceContext} from '@context/device';
@@ -142,4 +142,25 @@ export function useAvoidKeyboard(ref: RefObject<KeyboardAwareScrollView>, dimish
 
         ref.current?.scrollToPosition(0, offsetY);
     }, [height, dimisher, ref]);
+}
+
+export function useReduceMotion() {
+    const [reduceMotion, setReduceMotion] = useState(false);
+
+    useEffect(() => {
+        const checkReduceMotion = async () => {
+            const isReduceMotionEnabled = await AccessibilityInfo.isReduceMotionEnabled();
+            setReduceMotion(isReduceMotionEnabled);
+        };
+
+        checkReduceMotion();
+
+        const listener = AccessibilityInfo.addEventListener('reduceMotionChanged', setReduceMotion);
+
+        return () => {
+            listener.remove();
+        };
+    }, []);
+
+    return reduceMotion;
 }

--- a/app/screens/settings/display/display.tsx
+++ b/app/screens/settings/display/display.tsx
@@ -51,6 +51,17 @@ const TIMEZONE_FORMAT = [
     },
 ];
 
+const ANIMATION_FORMAT = [
+    {
+        id: t('display_settings.animations.on'),
+        defaultMessage: 'On',
+    },
+    {
+        id: t('display_settings.animations.off'),
+        defaultMessage: 'Off',
+    },
+];
+
 type DisplayProps = {
     componentId: AvailableScreens;
     currentUser?: UserModel;
@@ -125,6 +136,14 @@ const Display = ({componentId, currentUser, hasMilitaryTimeFormat, isCRTEnabled,
                     testID='display_settings.crt.option'
                 />
             )}
+            <SettingItem
+                optionName='animations'
+                label={intl.formatMessage({id: 'display_settings.animations', defaultMessage: 'Animations'})}
+                info={intl.formatMessage(ANIMATION_FORMAT[1])}
+                description={intl.formatMessage({id: 'display_settings.animations.description', defaultMessage: 'Uses system accessibility setting to disable animations'})}
+                testID='display_settings.animations.option'
+                type='info'
+            />
         </SettingContainer>
     );
 };


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A brief description of what this pull request does.
-->

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket or fixes a reported issue, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-mobile/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

#### Checklist
<!--
Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.
-->
- [ ] Added or updated unit tests (required for all new features)
- [ ] Has UI changes
- [ ] Includes text changes and localization file updates
- [ ] Have tested against the 5 core themes to ensure consistency between them.
- [ ] Have run E2E tests by adding label `E2E iOS tests for PR`.

#### Device Information
This PR was tested on: <!-- Device name(s), OS version(s) -->

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs/Videos (for both iOS and Android if possible).
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* New features and improvements, including behavioural changes, UI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Example:

```release-note
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```release-note
NONE
```
-->

```release-note

```

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add support for system's reduce motion setting to disable animations in `AnimatedNumber` and `AnimatedOptionBox`.
> 
>   - **Behavior**:
>     - `AnimatedNumber` and `AnimatedOptionBox` components now respect the system's reduce motion setting using `useReduceMotion` hook.
>     - If reduce motion is enabled, animations are disabled, and static content is displayed instead.
>   - **Hooks**:
>     - Adds `useReduceMotion` hook in `device.ts` to check system's reduce motion setting and listen for changes.
>   - **UI**:
>     - Adds an "Animations" setting in `display.tsx` to inform users about the use of system accessibility settings for animations.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=dashwave-test%2Fmattermost-mobile&utm_source=github&utm_medium=referral)<sup> for 01b838f8babdbe2a0d2cf7de18f8171fb1b6fe92. You can [customize](https://app.ellipsis.dev/dashwave-test/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->